### PR TITLE
Add sliding window limiter and add Redis

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,0 +1,3 @@
+Goal: Add distributed datastore for storing request data.
+Motivation: 
+    The inital work for implementing the `sliding window` rate limiting algorithm led to issues using the same Python dictionary with Flask's multi-threaded model. This was expected to arrive as the algorithm became more complex to support more clients

--- a/app/api.py
+++ b/app/api.py
@@ -10,5 +10,5 @@ app = Flask(__name__)
 
 @app.route("/")
 def status():
-    # print("Received request at {}".format(time.time()))
+    app.logger.info("Status: 200")
     return "Status: OK\n"

--- a/app/load-generator.py
+++ b/app/load-generator.py
@@ -15,4 +15,4 @@ for i in range(10000):
     time_delta = int(time.time()) - start
     if time_delta % 10 == 0:
         print("Making call {}".format(i))
-    time.sleep(0.2)
+    time.sleep(0.001)

--- a/app/sliding-window-limiter.py
+++ b/app/sliding-window-limiter.py
@@ -1,0 +1,77 @@
+from flask import Flask, request, Response, jsonify
+from redis import Redis
+from logging.config import dictConfig
+
+import time, requests
+import threading
+
+"""
+    A dummy API that returns a "status OK" message for use with 
+    various rate limiters under development.
+"""
+
+dictConfig({
+    'version': 1,
+    'formatters': {'default': {
+        'format': '%(levelname)s in %(module)s: %(message)s',
+    }},
+    'handlers': {'wsgi': {
+        'class': 'logging.StreamHandler',
+        'stream': 'ext://flask.logging.wsgi_errors_stream',
+        'formatter': 'default'
+    }},
+    'root': {
+        'level': 'INFO',
+        'handlers': ['wsgi']
+    }
+})
+
+app = Flask(__name__)
+
+redis_server = Redis.from_url('redis://request-store:6379/', decode_responses=True)
+
+api_address = "http://api:8080/"
+
+# Configuration dictionary of requests/second allowed
+rates = {
+    "default" : 3
+}
+
+@app.route("/")
+def rate_limit():
+    # Determine if the request should be forwarded to the app or rate limited
+    allowed = True
+
+    # Identify the source of the incoming request
+    identity = request.remote_addr
+    rate = rates["default"]
+
+    # Round time stamp to nearest millisecond
+    time_recv = round(time.time(), 3)
+
+    # Remove old data
+    removed = redis_server.zremrangebyscore(identity, 0, time_recv - 5)
+
+    # Check if the recorded request is within the limits
+    # Sum count for the past second
+    total_req = 0
+
+    past_req = redis_server.zrange(identity, time_recv-1, time_recv, byscore=True, withscores=True)
+    total_req = len(past_req)
+    # app.logger.info("Total requests: {}".format(total_req))
+    # app.logger.info("Requests: {}".format(past_req))
+
+    if total_req >= rate:
+        allowed = False
+
+    if allowed:
+        # Add a time stamp to the sorted set. Assume we don't have more than one request per millisecond
+        res = redis_server.zadd(identity, { time_recv : time_recv })
+        # Allowed - Make API call
+        resp = requests.get(api_address)
+        response, code = Response(resp.content, resp.status_code), resp.status_code
+    else:
+        # Not allowed - return 429
+        response, code = jsonify("Status: NOK"), 429
+
+    return response, code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     expose:
       - "8080"
     deploy:
-      replicas: 1
+      replicas: 3
       resources:
         limits:
           cpus: '0.25'
@@ -33,7 +33,7 @@ services:
     expose:
       - "8080"
     deploy:
-      replicas: 50
+      replicas: 10
       resources:
         limits:
           cpus: '0.5'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
 
   api:
     build: .
-    command: flask --app api run -p 8080 -h 0.0.0.0
+    command: gunicorn --bind 0.0.0.0:8080 api:app
     expose:
       - "8080"
     deploy:
@@ -11,11 +11,18 @@ services:
 
   limiter:
     build: .
-    command: flask --app window-limiter run -p 8080 -h 0.0.0.0
+    command: gunicorn --bind 0.0.0.0:8080 sliding-window-limiter:app
     expose:
       - "8080"
     deploy:
       replicas: 1
+      resources:
+        limits:
+          cpus: '0.25'
+          memory: 100M
+        reservations:
+          cpus: '0.25'
+          memory: 100M
 
   generator:
     build: .
@@ -26,4 +33,18 @@ services:
     expose:
       - "8080"
     deploy:
+      replicas: 50
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 500M
+        reservations:
+          cpus: '0.5'
+          memory: 500M
+
+  request-store:
+    image: redis:alpine
+    deploy:
       replicas: 1
+    ports:
+      - "6379:6379"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 requests
-Flask==3.0.0
+flask==3.0.0
+redis
+pottery==3.0.0
+gunicorn==21.2.0


### PR DESCRIPTION
This adds a new rate limiting algorithm by tracking the requests at 1 millisecond granularity to provide a more even measurement of the requests that came in over the previous second. 

To increase throughput of the rate limiter and provide a distributed system, the request tracking storage was changed from a Python dictionary to using Redis. 

The web server was also switched from the Flask development server to [gunicorn ](https://docs.gunicorn.org/en/latest/).